### PR TITLE
Fix ReferenceError in Firefox

### DIFF
--- a/source/App.tsx
+++ b/source/App.tsx
@@ -105,7 +105,7 @@ export default function App() {
                 </div>
 
                 <div className="pt-8 pr-8 drop-shadow-sm w-70vw flex flex-row justify-end align-middle gap-2ch">
-                    {chrome?.runtime ? null :
+                    {typeof chrome !== "undefined" && chrome.runtime ? null :
                         <a href="https://chromewebstore.google.com/detail/vimtips-plus/oppimlkbmphmnabeldemahpgpajincbb">
                             <img 
                                 className="w-15ch"


### PR DESCRIPTION
## Summary
- guard access to the global `chrome` object

## Testing
- `npm test`
- `npm run lint:react` *(fails: 44 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684bc97c94e4833282d992aed4bbc7ca